### PR TITLE
If non_key_attribute_classes is None, .get() raises error

### DIFF
--- a/pynamodb/models.py
+++ b/pynamodb/models.py
@@ -838,6 +838,7 @@ class Model(with_metaclass(MetaModel)):
         query_conditions = OrderedDict()
         non_key_operator_map = non_key_operator_map or {}
         key_attribute_classes = key_attribute_classes or {}
+        non_key_attribute_classes = non_key_attribute_classes or {}
         for attr_name, operator, value in cls._tokenize_filters(filters):
             attribute_class = key_attribute_classes.get(attr_name, None)
             if attribute_class is None:


### PR DESCRIPTION
Without my fix, just a few lines below this line raises error:
`attribute_class = non_key_attribute_classes.get(attr_name, None)`

Unless **non_key_attribute_classes** is a dictionary.