### PR TITLE
Pin Botocore To Working Version

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -3,3 +3,4 @@ PynamoDB is written and maintained by Jharrod LaFon and numerous contributors:
 * Craig Bruce
 * Adam Chainz
 * Andy Wolfe
+* Pior Bastida

--- a/pynamodb/__init__.py
+++ b/pynamodb/__init__.py
@@ -7,4 +7,4 @@ A simple abstraction over DynamoDB
 """
 __author__ = 'Jharrod LaFon'
 __license__ = 'MIT'
-__version__ = '1.3.5'
+__version__ = '1.3.6'

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ if sys.argv[-1] == 'publish':
 install_requires = [
     'Delorean',
     'six',
-    'botocore>=0.42.0'
+    'botocore==0.109.0'
 ]
 
 if sys.version_info[0] < 3:


### PR DESCRIPTION
PynamoDB isn't compatible with Botocore 1.0.0. This patch pins PynamoDB to a compatible version. This should serve as a bandaid until PynamoDB can be updated to support 1.0.0.