### PR TITLE
range_key in get fails with truthy Falses

### DIFF
--- a/pynamodb/connection/base.py
+++ b/pynamodb/connection/base.py
@@ -136,7 +136,7 @@ class MetaTable(object):
                 }
             }
         }
-        if range_key:
+        if range_key is not None:
             kwargs[key][self.range_keyname] = {
                 self.get_attribute_type(self.range_keyname): range_key
             }

--- a/pynamodb/models.py
+++ b/pynamodb/models.py
@@ -972,7 +972,7 @@ class Model(with_metaclass(MetaModel)):
         serialized = self._serialize(null_check=False)
         hash_key = serialized.get(HASH)
         range_key = serialized.get(RANGE, None)
-        if range_key:
+        if range_key is not None:
             kwargs[pythonic(RANGE_KEY)] = range_key
         kwargs[pythonic(ATTRIBUTES)] = serialized[pythonic(ATTRIBUTES)]
         return hash_key, kwargs
@@ -991,7 +991,7 @@ class Model(with_metaclass(MetaModel)):
         hash_key = serialized.get(HASH)
         range_key = serialized.get(RANGE, None)
         args = (hash_key, )
-        if range_key:
+        if range_key is not None:
             kwargs[pythonic(RANGE_KEY)] = range_key
         if attributes:
             kwargs[pythonic(ATTRIBUTES)] = serialized[pythonic(ATTRIBUTES)]
@@ -1176,6 +1176,6 @@ class Model(with_metaclass(MetaModel)):
         :param range_key: The range key value
         """
         hash_key = cls._hash_key_attribute().serialize(hash_key)
-        if range_key:
+        if range_key is not None:
             range_key = cls._range_key_attribute().serialize(range_key)
         return hash_key, range_key


### PR DESCRIPTION
Previously, if used a .get(hash_key, range_key) where bool(range_key)
was False, the range_key wouldn't actually show up in the query to
DynamoDB because the get_identifier_map function would simply use
the truthy evaluation `if range_key`. By changing this to an
explicit `if range_key is not None`, this allows gets when a Python
value would otherwise evaluate to False, e.g., 0.