### PR TITLE
use boto to prepare request only

### DIFF
--- a/pynamodb/connection/base.py
+++ b/pynamodb/connection/base.py
@@ -256,7 +256,6 @@ class Connection(object):
         """
         if self._requests_session is None:
             self._requests_session = requests.Session()
-            self._requests_session.headers['Accept-Encoding'] = 'gzip,deflate'
         return self._requests_session
 
     @property

--- a/pynamodb/connection/base.py
+++ b/pynamodb/connection/base.py
@@ -3,11 +3,11 @@ Lowest level connection
 """
 import logging
 
-import requests
 import six
 from botocore.session import get_session
 from botocore.exceptions import BotoCoreError
 from botocore.client import ClientError
+from botocore.vendored import requests
 
 from .util import pythonic
 from ..types import HASH, RANGE


### PR DESCRIPTION
I'm opening this pull request primarily to start a discussion.

This is a hack I did to circumvent boto's poor performance when parsing request bodies. It's unfortunate because it requires accessing underscore "protected" members of boto. It does improve performance significantly.

There is also behavior around error handling and exceptions from boto that need to be replicated. Maybe checking the status code and throwing on non-200s would be enough. I haven't explored PynamoDB's behavior in error scenarios yet.

TODO:
- [ ] fix tests