### PR TITLE
Support Streams

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -138,6 +138,26 @@ Want to use DynamoDB local? Just add a ``host`` name attribute and specify your 
         first_name = UnicodeAttribute(range_key=True)
         last_name = UnicodeAttribute(hash_key=True)
 
+Want to enable streams on a table? Just add a ``stream_view_type`` name attribute and specify
+the type of data you'd like to stream.
+
+.. code-block:: python
+
+    from pynamodb.models import Model
+    from pynamodb.attributes import UnicodeAttribute
+    from pynamodb.constants import STREAM_NEW_AND_OLD_IMAGE
+
+    class AnimalModel(Model):
+        """
+        A DynamoDB Animal
+        """
+        class Meta:
+            table_name = "dynamodb-user"
+            host = "http://localhost:8000"
+            stream_view_type = STREAM_NEW_AND_OLD_IMAGE
+        type = UnicodeAttribute(null=True)
+        name = UnicodeAttribute(range_key=True)
+        id = UnicodeAttribute(hash_key=True)
 
 Want to backup and restore a table? No problem.
 

--- a/pynamodb/connection/base.py
+++ b/pynamodb/connection/base.py
@@ -31,7 +31,7 @@ from pynamodb.constants import (
     CONSUMED_CAPACITY, CAPACITY_UNITS, QUERY_FILTER, QUERY_FILTER_VALUES, CONDITIONAL_OPERATOR,
     CONDITIONAL_OPERATORS, NULL, NOT_NULL, SHORT_ATTR_TYPES,
     ITEMS, DEFAULT_ENCODING, BINARY_SHORT, BINARY_SET_SHORT, LAST_EVALUATED_KEY, RESPONSES, UNPROCESSED_KEYS,
-    UNPROCESSED_ITEMS)
+    UNPROCESSED_ITEMS, STREAM_SPECIFICATION, STREAM_VIEW_TYPE, STREAM_ENABLED)
 
 BOTOCORE_EXCEPTIONS = (BotoCoreError, ClientError)
 
@@ -324,7 +324,8 @@ class Connection(object):
                      read_capacity_units=None,
                      write_capacity_units=None,
                      global_secondary_indexes=None,
-                     local_secondary_indexes=None):
+                     local_secondary_indexes=None,
+                     stream_specification=None):
         """
         Performs the CreateTable operation
         """
@@ -375,6 +376,13 @@ class Connection(object):
                     PROJECTION: index.get(pythonic(PROJECTION)),
                 })
             operation_kwargs[LOCAL_SECONDARY_INDEXES] = local_secondary_indexes_list
+
+        if stream_specification:
+            operation_kwargs[STREAM_SPECIFICATION] = {
+                STREAM_ENABLED: stream_specification[pythonic(STREAM_ENABLED)],
+                STREAM_VIEW_TYPE: stream_specification[pythonic(STREAM_VIEW_TYPE)]
+            }
+
         try:
             data = self.dispatch(CREATE_TABLE, operation_kwargs)
         except BOTOCORE_EXCEPTIONS as e:

--- a/pynamodb/connection/table.py
+++ b/pynamodb/connection/table.py
@@ -205,7 +205,8 @@ class TableConnection(object):
                      read_capacity_units=None,
                      write_capacity_units=None,
                      global_secondary_indexes=None,
-                     local_secondary_indexes=None):
+                     local_secondary_indexes=None,
+                     stream_specification=None):
         """
         Performs the CreateTable operation and returns the result
         """
@@ -216,5 +217,6 @@ class TableConnection(object):
             read_capacity_units=read_capacity_units,
             write_capacity_units=write_capacity_units,
             global_secondary_indexes=global_secondary_indexes,
-            local_secondary_indexes=local_secondary_indexes
+            local_secondary_indexes=local_secondary_indexes,
+            stream_specification=stream_specification
         )

--- a/pynamodb/constants.py
+++ b/pynamodb/constants.py
@@ -114,6 +114,15 @@ KEYS_ONLY = 'KEYS_ONLY'
 ALL = 'ALL'
 INCLUDE = 'INCLUDE'
 
+# Constants for Dynamodb Streams
+STREAM_VIEW_TYPE = 'StreamViewType'
+STREAM_SPECIFICATION = 'StreamSpecification'
+STREAM_ENABLED = 'StreamEnabled'
+STREAM_NEW_IMAGE = 'NEW_IMAGE'
+STREAM_OLD_IMAGE = 'OLD_IMAGE'
+STREAM_NEW_AND_OLD_IMAGE = 'NEW_AND_OLD_IMAGES'
+STREAM_KEYS_ONLY = 'KEYS_ONLY'
+
 # These are constants used in the KeyConditions parameter
 # See: http://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_Query.html#DDB-Query-request-KeyConditions
 EXCLUSIVE_START_KEY = 'ExclusiveStartKey'

--- a/pynamodb/models.py
+++ b/pynamodb/models.py
@@ -29,7 +29,8 @@ from pynamodb.constants import (
     SCAN_OPERATOR_MAP, CONSUMED_CAPACITY, BATCH_WRITE_PAGE_LIMIT, TABLE_NAME,
     CAPACITY_UNITS, DEFAULT_REGION, META_CLASS_NAME, REGION, HOST, EXISTS, NULL,
     DELETE_FILTER_OPERATOR_MAP, UPDATE_FILTER_OPERATOR_MAP, PUT_FILTER_OPERATOR_MAP,
-    COUNT, ITEM_COUNT, KEY, UNPROCESSED_ITEMS)
+    COUNT, ITEM_COUNT, KEY, UNPROCESSED_ITEMS, STREAM_VIEW_TYPE, STREAM_SPECIFICATION,
+    STREAM_ENABLED)
 
 
 log = logging.getLogger(__name__)
@@ -671,6 +672,11 @@ class Model(with_metaclass(MetaModel)):
                 schema[pythonic(READ_CAPACITY_UNITS)] = cls.Meta.read_capacity_units
             if hasattr(cls.Meta, pythonic(WRITE_CAPACITY_UNITS)):
                 schema[pythonic(WRITE_CAPACITY_UNITS)] = cls.Meta.write_capacity_units
+            if hasattr(cls.Meta, pythonic(STREAM_VIEW_TYPE)):
+                schema[pythonic(STREAM_SPECIFICATION)] = {
+                    pythonic(STREAM_ENABLED): True,
+                    pythonic(STREAM_VIEW_TYPE): cls.Meta.stream_view_type
+                }
             if read_capacity_units is not None:
                 schema[pythonic(READ_CAPACITY_UNITS)] = read_capacity_units
             if write_capacity_units is not None:

--- a/pynamodb/tests/test_base_connection.py
+++ b/pynamodb/tests/test_base_connection.py
@@ -182,6 +182,22 @@ class ConnectionTestCase(TestCase):
             )
             self.assertEqual(req.call_args[0][1], params)
 
+        kwargs['stream_specification'] = {
+                'stream_enabled': True,
+                'stream_view_type': 'NEW_IMAGE'
+        }
+        params['StreamSpecification'] = {
+                'StreamEnabled': True,
+                'StreamViewType': 'NEW_IMAGE'
+        }
+        with patch(PATCH_METHOD) as req:
+            req.return_value = None
+            conn.create_table(
+                self.test_table_name,
+                **kwargs
+            )
+            self.assertEqual(req.call_args[0][1], params)
+
     def test_delete_table(self):
         """
         Connection.delete_table

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 sphinx-rtd-theme==0.1.8
 mock==1.0.1
 Delorean==0.4.5
-botocore==1.0.0
+botocore==1.1.2
 flake8==2.4.1
 nose==1.3.7
 requests==2.7.0


### PR DESCRIPTION
Botocore v1.1.2 supports new parameters for adding a stream to a dynamo
table on creation. It's relatively straightforward to add an interface
for doing this on Pynamodb table creation, so add that.