### PR TITLE
Return the cause of connection exceptions to the caller.

### DIFF
--- a/pynamodb/exceptions.py
+++ b/pynamodb/exceptions.py
@@ -7,8 +7,9 @@ class PynamoDBException(Exception):
     """
     A common exception class
     """
-    def __init__(self, msg=None):
+    def __init__(self, msg=None, cause=None):
         self.msg = msg or self.msg
+        self.cause = cause
         super(PynamoDBException, self).__init__(self.msg)
 
 


### PR DESCRIPTION
Extract the DynamoDB error code from non-200 responses and return it to the caller when throwing Connection Exceptions. This provides a mechanism for the caller to modify their error behavior the error type (e.g. ConditionalCheckFailedException vs InternalServerError).