### PR TITLE
Treat UnprocessedItems as dict of list of dicts

### DIFF
--- a/pynamodb/connection/base.py
+++ b/pynamodb/connection/base.py
@@ -273,7 +273,7 @@ class Connection(object):
                         _convert_binary(attr)
         if UNPROCESSED_ITEMS in data:
             for item_mapping in six.itervalues(data[UNPROCESSED_ITEMS]):
-                for item in six.itervalues(item_mapping):
+                for item in item_mapping:
                     for attr in six.itervalues(item):
                         _convert_binary(attr)
 


### PR DESCRIPTION
Previously, when a BatchWriteItem call returned UnprocessedItems, Pynamo
incorrectly assumed that it was a dict of dict of dicts, when it was
actually a dict of list of dicts.