### PR TITLE
Make limit inclusive. Add query limit tests.

### DIFF
--- a/pynamodb/models.py
+++ b/pynamodb/models.py
@@ -564,11 +564,12 @@ class Model(with_metaclass(MetaModel)):
         last_evaluated_key = data.get(LAST_EVALUATED_KEY, None)
 
         for item in data.get(ITEMS):
-            if limit is not None:
-                if limit == 0:
-                    return
-                limit -= 1
+            if limit == 0:
+                return
             yield cls.from_raw_data(item)
+            # decrement after returning item
+            if limit is not None:
+                limit -= 1
 
         while last_evaluated_key:
             log.debug("Fetching query page with exclusive start key: %s", last_evaluated_key)


### PR DESCRIPTION
Related to issue [#95](https://github.com/jlafon/PynamoDB/issues/95), which is already closed but doesn't seem to work.

So, this returns the correct number of results. Example: when limit is 5 and there are at
least 5 matches return 5 items.

Hopefully I wrote the tests properly, not very experienced with testing. Please look at it.

Thanks!