### PR TITLE
retry on RequestExceptions only

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ pip-log.txt
 
 # Unit test / coverage reports
 .coverage
+cover/
 .tox
 nosetests.xml
 

--- a/pynamodb/tests/test_base_connection.py
+++ b/pynamodb/tests/test_base_connection.py
@@ -1691,7 +1691,7 @@ class ConnectionTestCase(TestCase):
 
     @mock.patch('pynamodb.connection.Connection.session')
     @mock.patch('pynamodb.connection.Connection.requests_session')
-    def test_make_api_call_retries_properly(self, requests_session_mock, session_mock):
+    def test_make_api_call_throws_when_retries_exhausted(self, requests_session_mock, session_mock):
         prepared_request = requests.Request('GET', 'http://lyft.com').prepare()
         session_mock.create_client.return_value._endpoint.create_request.return_value = prepared_request
 

--- a/pynamodb/tests/test_base_connection.py
+++ b/pynamodb/tests/test_base_connection.py
@@ -1668,8 +1668,10 @@ class ConnectionTestCase(TestCase):
         # mock response
         deserializable_response = requests.Response()
         deserializable_response._content = json.dumps({'hello': 'world'}).encode('utf-8')
+        deserializable_response.status_code = 200
         bad_response = requests.Response()
         bad_response._content = 'not_json'.encode('utf-8')
+        bad_response.status_code = 503
 
         prepared_request = requests.Request('GET', 'http://lyft.com').prepare()
         session_mock.create_client.return_value._endpoint.create_request.return_value = prepared_request

--- a/pynamodb/tests/test_base_connection.py
+++ b/pynamodb/tests/test_base_connection.py
@@ -1669,7 +1669,7 @@ class ConnectionTestCase(TestCase):
         deserializable_response = requests.Response()
         deserializable_response._content = json.dumps({'hello': 'world'})
         bad_response = requests.Response()
-        bad_response._content = 'not_json'
+        bad_response._content = 'not_json'.encode('utf-8')
 
         prepared_request = requests.Request('GET', 'http://lyft.com').prepare()
         session_mock.create_client.return_value._endpoint.create_request.return_value = prepared_request

--- a/pynamodb/tests/test_base_connection.py
+++ b/pynamodb/tests/test_base_connection.py
@@ -1667,7 +1667,7 @@ class ConnectionTestCase(TestCase):
     def test_make_api_call_retries_properly(self, requests_session_mock, session_mock):
         # mock response
         deserializable_response = requests.Response()
-        deserializable_response._content = json.dumps({'hello': 'world'})
+        deserializable_response._content = json.dumps({'hello': 'world'}).encode('utf-8')
         bad_response = requests.Response()
         bad_response._content = 'not_json'.encode('utf-8')
 


### PR DESCRIPTION
Fixes #98. Should alleviate most of the problems users are having in production, though some may still be more comfortable with legacy botocore behavior of retrying on everything. At any rate that will take some more time to implement and come in another PR and should be highly configurable.

This PR does not retry based on status code or error code from DynamoDB. RequestExceptions can be retried quickly without need for exponential backoff and more granular handling so I have implemented it first.

I included private variables with the retry parameters in case someone wants to get at them, but it should  be considered an interface that won't be maintained and might break between minor releases.

TODO:
- [x] tests