### PR TITLE
Fix handling of binary attr unprocessed

### DIFF
--- a/pynamodb/connection/base.py
+++ b/pynamodb/connection/base.py
@@ -306,34 +306,39 @@ class Connection(object):
 
                 raise VerboseClientError(botocore_expected_format, operation_name, verbose_properties)
 
-            # Simulate botocore's binary attribute handling
-            if ITEM in data:
-                for attr in six.itervalues(data[ITEM]):
+            return self._handle_binary_attributes(data)
+
+    @staticmethod
+    def _handle_binary_attributes(data):
+        """ Simulate botocore's binary attribute handling """
+        if ITEM in data:
+            for attr in six.itervalues(data[ITEM]):
+                _convert_binary(attr)
+        if ITEMS in data:
+            for item in data[ITEMS]:
+                for attr in six.itervalues(item):
                     _convert_binary(attr)
-            if ITEMS in data:
-                for item in data[ITEMS]:
+        if RESPONSES in data:
+            for item_list in six.itervalues(data[RESPONSES]):
+                for item in item_list:
                     for attr in six.itervalues(item):
                         _convert_binary(attr)
-            if RESPONSES in data:
-                for item_list in six.itervalues(data[RESPONSES]):
-                    for item in item_list:
-                        for attr in six.itervalues(item):
-                            _convert_binary(attr)
-            if LAST_EVALUATED_KEY in data:
-                for attr in six.itervalues(data[LAST_EVALUATED_KEY]):
-                    _convert_binary(attr)
-            if UNPROCESSED_KEYS in data:
-                for item_list in six.itervalues(data[UNPROCESSED_KEYS]):
-                    for item in item_list:
-                        for attr in six.itervalues(item):
-                            _convert_binary(attr)
-            if UNPROCESSED_ITEMS in data:
-                for item_mapping in six.itervalues(data[UNPROCESSED_ITEMS]):
-                    for item in item_mapping:
-                        for attr in six.itervalues(item):
-                            _convert_binary(attr)
-
-            return data
+        if LAST_EVALUATED_KEY in data:
+            for attr in six.itervalues(data[LAST_EVALUATED_KEY]):
+                _convert_binary(attr)
+        if UNPROCESSED_KEYS in data:
+            for item_list in six.itervalues(data[UNPROCESSED_KEYS]):
+                for item in item_list:
+                    for attr in six.itervalues(item):
+                        _convert_binary(attr)
+        if UNPROCESSED_ITEMS in data:
+            for table_unprocessed_requests in six.itervalues(data[UNPROCESSED_ITEMS]):
+                for request in table_unprocessed_requests:
+                    for item_mapping in six.itervalues(request):
+                        for item in six.itervalues(item_mapping):
+                            for attr in six.itervalues(item):
+                                _convert_binary(attr)
+        return data
 
     @property
     def session(self):

--- a/pynamodb/tests/test_base_connection.py
+++ b/pynamodb/tests/test_base_connection.py
@@ -9,7 +9,7 @@ from pynamodb.connection import Connection
 from botocore.vendored import requests
 from pynamodb.exceptions import (
     TableError, DeleteError, UpdateError, PutError, GetError, ScanError, QueryError, TableDoesNotExist)
-from pynamodb.constants import DEFAULT_REGION, UNPROCESSED_ITEMS, STRING_SHORT, BINARY_SHORT
+from pynamodb.constants import DEFAULT_REGION, UNPROCESSED_ITEMS, STRING_SHORT, BINARY_SHORT, DEFAULT_ENCODING
 from pynamodb.tests.data import DESCRIBE_TABLE_DATA, GET_ITEM_DATA, LIST_TABLE_DATA
 from pynamodb.tests.deep_eq import deep_eq
 from botocore.exceptions import BotoCoreError
@@ -1716,7 +1716,7 @@ class ConnectionTestCase(TestCase):
             self.assertEqual(call[:2], ('send', (prepared_request,)))
 
     def test_handle_binary_attributes_for_unprocessed_items(self):
-        binary_blob = b'\x00\xFF\x00\xFF'
+        binary_blob = six.b('\x00\xFF\x00\xFF')
 
         unprocessed_items = []
         for idx in range(0, 5):
@@ -1724,7 +1724,7 @@ class ConnectionTestCase(TestCase):
                 'PutRequest': {
                     'Item': {
                         'name': {STRING_SHORT: 'daniel'},
-                        'picture': {BINARY_SHORT: base64.b64encode(binary_blob)}
+                        'picture': {BINARY_SHORT: base64.b64encode(binary_blob).decode(DEFAULT_ENCODING)}
                     }
                 }
             })

--- a/pynamodb/tests/test_base_connection.py
+++ b/pynamodb/tests/test_base_connection.py
@@ -1,6 +1,7 @@
 """
 Tests for the base connection class
 """
+import base64
 import json
 import six
 from pynamodb.compat import CompatTestCase as TestCase
@@ -8,8 +9,9 @@ from pynamodb.connection import Connection
 from botocore.vendored import requests
 from pynamodb.exceptions import (
     TableError, DeleteError, UpdateError, PutError, GetError, ScanError, QueryError, TableDoesNotExist)
-from pynamodb.constants import DEFAULT_REGION
+from pynamodb.constants import DEFAULT_REGION, UNPROCESSED_ITEMS, STRING_SHORT, BINARY_SHORT
 from pynamodb.tests.data import DESCRIBE_TABLE_DATA, GET_ITEM_DATA, LIST_TABLE_DATA
+from pynamodb.tests.deep_eq import deep_eq
 from botocore.exceptions import BotoCoreError
 from botocore.client import ClientError
 
@@ -1712,3 +1714,35 @@ class ConnectionTestCase(TestCase):
         self.assertEqual(len(requests_session_mock.mock_calls), 4)
         for call in requests_session_mock.mock_calls:
             self.assertEqual(call[:2], ('send', (prepared_request,)))
+
+    def test_handle_binary_attributes_for_unprocessed_items(self):
+        binary_blob = b'\x00\xFF\x00\xFF'
+
+        unprocessed_items = []
+        for idx in range(0, 5):
+            unprocessed_items.append({
+                'PutRequest': {
+                    'Item': {
+                        'name': {STRING_SHORT: 'daniel'},
+                        'picture': {BINARY_SHORT: base64.b64encode(binary_blob)}
+                    }
+                }
+            })
+
+        expected_unprocessed_items = []
+        for idx in range(0, 5):
+            expected_unprocessed_items.append({
+                'PutRequest': {
+                    'Item': {
+                        'name': {STRING_SHORT: 'daniel'},
+                        'picture': {BINARY_SHORT: binary_blob}
+                    }
+                }
+            })
+
+        deep_eq(
+            Connection._handle_binary_attributes({UNPROCESSED_ITEMS: {'someTable': unprocessed_items}}),
+            {UNPROCESSED_ITEMS: {'someTable': expected_unprocessed_items}},
+            _assert=True
+        )
+

--- a/pynamodb/tests/test_model.py
+++ b/pynamodb/tests/test_model.py
@@ -1803,14 +1803,6 @@ class ModelTestCase(TestCase):
                     batch.save(item)
 
     def test_batch_write_with_unprocessed(self):
-        items = []
-        for idx in range(10):
-            item = copy.copy(GET_MODEL_ITEM_DATA.get(ITEM))
-            item['user_id'] = {STRING_SHORT: 'id-{0}'.format(idx)}
-            item['email'] = {STRING_SHORT: 'email-{0}'.format(random.randint(0, 65536))}
-            item['picture'] = {BINARY_SHORT: BINARY_ATTR_DATA}
-            items.append(item)
-
         picture_blob = b'FFD8FFD8'
 
         items = []

--- a/pynamodb/tests/test_model.py
+++ b/pynamodb/tests/test_model.py
@@ -19,7 +19,7 @@ from pynamodb.types import RANGE
 from pynamodb.constants import (
     ITEM, STRING_SHORT, ALL, KEYS_ONLY, INCLUDE, REQUEST_ITEMS, UNPROCESSED_KEYS, ITEM_COUNT,
     RESPONSES, KEYS, ITEMS, LAST_EVALUATED_KEY, EXCLUSIVE_START_KEY, ATTRIBUTES, BINARY_SHORT,
-    UNPROCESSED_ITEMS
+    UNPROCESSED_ITEMS, DEFAULT_ENCODING
 )
 from pynamodb.models import Model
 from pynamodb.indexes import (
@@ -1828,7 +1828,7 @@ class ModelTestCase(TestCase):
                     'Item': {
                         'custom_username': {STRING_SHORT: 'daniel'},
                         'user_id': {STRING_SHORT: '{}'.format(idx)},
-                        'picture': {BINARY_SHORT: base64.b64encode(picture_blob)}
+                        'picture': {BINARY_SHORT: base64.b64encode(picture_blob).decode(DEFAULT_ENCODING)}
                     }
                 }
             })

--- a/pynamodb/tests/test_model.py
+++ b/pynamodb/tests/test_model.py
@@ -1817,7 +1817,7 @@ class ModelTestCase(TestCase):
         for idx in range(10):
             items.append(UserModel(
                 'daniel',
-                '{}'.format(idx),
+                '{0}'.format(idx),
                 picture=picture_blob,
             ))
 
@@ -1827,7 +1827,7 @@ class ModelTestCase(TestCase):
                 'PutRequest': {
                     'Item': {
                         'custom_username': {STRING_SHORT: 'daniel'},
-                        'user_id': {STRING_SHORT: '{}'.format(idx)},
+                        'user_id': {STRING_SHORT: '{0}'.format(idx)},
                         'picture': {BINARY_SHORT: base64.b64encode(picture_blob).decode(DEFAULT_ENCODING)}
                     }
                 }


### PR DESCRIPTION
fixes #125 

- moved binary attribute handling to its own method and added a test for this specific error case
- fixed the test for re-batch_writing unprocessed items since it wasn't doing anything before

worth noting that #97 #114 #120 all got it wrong, at least i think #97 did, the approach is a little different

I read the spec and reimplemented correctly http://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_BatchWriteItem.html#API_BatchWriteItem_ResponseSyntax
