### PR TITLE
Fixing incorrect manipulation of limit value during pagination

### DIFF
--- a/pynamodb/models.py
+++ b/pynamodb/models.py
@@ -572,11 +572,7 @@ class Model(with_metaclass(MetaModel)):
 
         while last_evaluated_key:
             log.debug("Fetching query page with exclusive start key: %s", last_evaluated_key)
-            # If the user provided a limit, we need to subtract the number of results returned for each page
-            if limit is not None:
-                if limit == 0:
-                    return
-                limit -= data.get(CAMEL_COUNT, 0)
+
             query_kwargs['exclusive_start_key'] = last_evaluated_key
             query_kwargs['limit'] = limit
             log.debug("Fetching query page with exclusive start key: %s", last_evaluated_key)


### PR DESCRIPTION
Today - The limit variable input is being used, as keep getting items until you have retrieved a value equal to X. 

This variable when passed to DynamoDB is interpreted as page size.

The bug involves subtracting item count from the Limit, twice, instead of once.

This PR separates does not fix the incorrect use of Limit, but merely fixes the bug where value of limit is decremented twice.