### PR TITLE
Serialize UnicodeSetAttributes correctly

### DIFF
--- a/pynamodb/attributes.py
+++ b/pynamodb/attributes.py
@@ -160,7 +160,7 @@ class UnicodeSetAttribute(SetMixin, Attribute):
                 result_set = set()
                 for str_val in value:
                     result_set.add(str(str_val))
-                return result_set
+                return list(result_set)
         return None
 
     def deserialize(self, value):

--- a/pynamodb/attributes.py
+++ b/pynamodb/attributes.py
@@ -120,6 +120,22 @@ class BinarySetAttribute(SetMixin, Attribute):
     attr_type = BINARY_SET
     null = True
 
+    def serialize(self, value):
+        """
+        Returns a base64 encoded binary string
+        """
+        if value and len(value):
+            return [b64encode(val).decode(DEFAULT_ENCODING) for val in sorted(value)]
+        else:
+            return None
+
+    def deserialize(self, value):
+        """
+        Returns a decoded string from base64
+        """
+        if value and len(value):
+            return set([b64decode(val.encode(DEFAULT_ENCODING)) for val in value])
+
 
 class UnicodeSetAttribute(SetMixin, Attribute):
     """

--- a/pynamodb/attributes.py
+++ b/pynamodb/attributes.py
@@ -63,34 +63,6 @@ class Attribute(object):
         return value.get(serialized_dynamo_type)
 
 
-class SetMixin(object):
-    """
-    Adds (de)serialization methods for sets
-    """
-    def serialize(self, value):
-        """
-        Serializes a set
-
-        Because dynamodb doesn't store empty attributes,
-        empty sets return None
-        """
-        if value is not None:
-            try:
-                iter(value)
-            except TypeError:
-                value = [value]
-            if len(value):
-                return [json.dumps(val) for val in sorted(value)]
-        return None
-
-    def deserialize(self, value):
-        """
-        Deserializes a set
-        """
-        if value and len(value):
-            return set([json.loads(val) for val in value])
-
-
 class BinaryAttribute(Attribute):
     """
     A binary attribute
@@ -113,7 +85,7 @@ class BinaryAttribute(Attribute):
             return b64decode(value)
 
 
-class BinarySetAttribute(SetMixin, Attribute):
+class BinarySetAttribute(Attribute):
     """
     A binary set
     """
@@ -137,7 +109,7 @@ class BinarySetAttribute(SetMixin, Attribute):
             return set([b64decode(val.encode(DEFAULT_ENCODING)) for val in value])
 
 
-class UnicodeSetAttribute(SetMixin, Attribute):
+class UnicodeSetAttribute(Attribute):
     """
     A unicode set
     """
@@ -270,12 +242,35 @@ class BooleanAttribute(Attribute):
         return value_to_deserialize
 
 
-class NumberSetAttribute(SetMixin, Attribute):
+class NumberSetAttribute(Attribute):
     """
     A number set attribute
     """
     attr_type = NUMBER_SET
     null = True
+
+    def serialize(self, value):
+        """
+        Serializes a set
+
+        Because dynamodb doesn't store empty attributes,
+        empty sets return None
+        """
+        if value is not None:
+            try:
+                iter(value)
+            except TypeError:
+                value = [value]
+            if len(value):
+                return [json.dumps(val) for val in sorted(value)]
+        return None
+
+    def deserialize(self, value):
+        """
+        Deserializes a set
+        """
+        if value and len(value):
+            return set([json.loads(val) for val in value])
 
 
 class NumberAttribute(Attribute):

--- a/pynamodb/attributes.py
+++ b/pynamodb/attributes.py
@@ -145,11 +145,25 @@ class UnicodeSetAttribute(SetMixin, Attribute):
     null = True
 
     def element_serialize(self, value):
+        """
+        This serializes unicode / strings out as unicode strings.
+        It does not touch the value if it is already a unicode str
+        :param value:
+        :return:
+        """
         if isinstance(value, six.text_type):
             return value
         return six.u(str(value))
 
     def element_deserialize(self, value):
+        """
+        This deserializes what we get from mongo back into a str
+        Serialization previously json encoded strings. This caused them to have
+        extra double quote (") characters. That no longer happens.
+        This method allows both types of serialized values to be read
+        :param value:
+        :return:
+        """
         result = value
         try:
             result = json.loads(value)
@@ -159,12 +173,6 @@ class UnicodeSetAttribute(SetMixin, Attribute):
         return result
 
     def serialize(self, value):
-        """
-        Serializes a set
-
-        Because dynamodb doesn't store empty attributes,
-        empty sets return None
-        """
         if value is not None:
             try:
                 iter(value)
@@ -175,9 +183,6 @@ class UnicodeSetAttribute(SetMixin, Attribute):
         return None
 
     def deserialize(self, value):
-        """
-        Deserializes a set
-        """
         if value and len(value):
             return set([self.element_deserialize(val) for val in value])
 

--- a/pynamodb/attributes.py
+++ b/pynamodb/attributes.py
@@ -157,7 +157,10 @@ class UnicodeSetAttribute(SetMixin, Attribute):
             except TypeError:
                 value = [value]
             if len(value):
-                return value
+                result_set = set()
+                for str_val in value:
+                    result_set.add(str(str_val))
+                return result_set
         return None
 
     def deserialize(self, value):

--- a/pynamodb/attributes.py
+++ b/pynamodb/attributes.py
@@ -144,6 +144,29 @@ class UnicodeSetAttribute(SetMixin, Attribute):
     attr_type = STRING_SET
     null = True
 
+    def serialize(self, value):
+        """
+        Serializes a set
+
+        Because dynamodb doesn't store empty attributes,
+        empty sets return None
+        """
+        if value is not None:
+            try:
+                iter(value)
+            except TypeError:
+                value = [value]
+            if len(value):
+                return value
+        return None
+
+    def deserialize(self, value):
+        """
+        Deserializes a set
+        """
+        if value and len(value):
+            return set(value)
+
 
 class UnicodeAttribute(Attribute):
     """

--- a/pynamodb/attributes.py
+++ b/pynamodb/attributes.py
@@ -145,7 +145,9 @@ class UnicodeSetAttribute(SetMixin, Attribute):
     null = True
 
     def element_serialize(self, value):
-        return str(value)
+        if isinstance(value, six.text_type):
+            return value
+        return six.u(value)
 
     def element_deserialize(self, value):
         result = value

--- a/pynamodb/attributes.py
+++ b/pynamodb/attributes.py
@@ -80,14 +80,13 @@ class SetMixin(object):
         Because dynamodb doesn't store empty attributes,
         empty sets return None
         """
-        if value is None:
-            return None
-        try:
-            iter(value)
-        except TypeError:
-            value = [value]
-        if len(value):
-            return [self.element_serialize(val) for val in sorted(value)]
+        if value is not None:
+            try:
+                iter(value)
+            except TypeError:
+                value = [value]
+            if len(value):
+                return [self.element_serialize(val) for val in sorted(value)]
         return None
 
     def deserialize(self, value):

--- a/pynamodb/attributes.py
+++ b/pynamodb/attributes.py
@@ -147,7 +147,7 @@ class UnicodeSetAttribute(SetMixin, Attribute):
     def element_serialize(self, value):
         if isinstance(value, six.text_type):
             return value
-        return six.u(value)
+        return six.u(str(value))
 
     def element_deserialize(self, value):
         result = value

--- a/pynamodb/attributes.py
+++ b/pynamodb/attributes.py
@@ -66,13 +66,12 @@ class Attribute(object):
 class SetMixin(object):
     """
     Adds (de)serialization methods for sets
-
+    """
     def element_serialize(self, value):
         raise NotImplemented()
 
     def element_deserialize(self, value):
         raise NotImplemented()
-    """
 
     def serialize(self, value):
         """
@@ -129,7 +128,7 @@ class BinaryAttribute(BinaryAttributeMixin, Attribute):
         return self.element_deserialize(value)
 
 
-class BinarySetAttribute(SetMixin, BinaryAttributeMixin, Attribute):
+class BinarySetAttribute(BinaryAttributeMixin, SetMixin, Attribute):
     """
     A binary set
     """
@@ -266,7 +265,7 @@ class NumberAttributeMixin(object):
         return json.loads(value)
 
 
-class NumberSetAttribute(SetMixin, NumberAttributeMixin, Attribute):
+class NumberSetAttribute(NumberAttributeMixin, SetMixin, Attribute):
     """
     A number set attribute
     """

--- a/pynamodb/attributes.py
+++ b/pynamodb/attributes.py
@@ -91,7 +91,7 @@ class SetMixin(object):
             return set([json.loads(val) for val in value])
 
 
-class BinaryAttribute(SetMixin, Attribute):
+class BinaryAttribute(Attribute):
     """
     A binary attribute
     """

--- a/pynamodb/attributes.py
+++ b/pynamodb/attributes.py
@@ -168,7 +168,13 @@ class UnicodeSetAttribute(SetMixin, Attribute):
         Deserializes a set
         """
         if value and len(value):
-            return set(value)
+            result = value
+            try:
+                result = [json.loads(val) for val in value]
+            except ValueError:
+                # it's serialized in the new way so pass
+                pass
+            return set(result)
 
 
 class UnicodeAttribute(Attribute):

--- a/pynamodb/tests/test_attributes.py
+++ b/pynamodb/tests/test_attributes.py
@@ -335,7 +335,7 @@ class UnicodeAttributeTestCase(TestCase):
         self.assertEqual(attr.deserialize(None), None)
         self.assertEqual(
             attr.serialize(set([six.u('foo'), six.u('bar')])),
-            [six.u('foo'), six.u('bar')]
+            sorted([six.u('foo'), six.u('bar')])
         )
 
     def test_round_trip_unicode_set(self):

--- a/pynamodb/tests/test_attributes.py
+++ b/pynamodb/tests/test_attributes.py
@@ -335,7 +335,8 @@ class UnicodeAttributeTestCase(TestCase):
         self.assertEqual(attr.deserialize(None), None)
         self.assertEqual(
             attr.serialize(set([six.u('foo'), six.u('bar')])),
-            [json.dumps(val) for val in sorted(set([six.u('foo'), six.u('bar')]))])
+            set([six.u('foo'), six.u('bar')])
+        )
 
     def test_round_trip_unicode_set(self):
         """
@@ -353,9 +354,10 @@ class UnicodeAttributeTestCase(TestCase):
         UnicodeSetAttribute.deserialize
         """
         attr = UnicodeSetAttribute()
+        value = set([six.u('foo'), six.u('bar')])
         self.assertEqual(
-            attr.deserialize([json.dumps(val) for val in sorted(set([six.u('foo'), six.u('bar')]))]),
-            set([six.u('foo'), six.u('bar')])
+            attr.deserialize(value),
+            value
         )
 
     def test_unicode_set_attribute(self):

--- a/pynamodb/tests/test_attributes.py
+++ b/pynamodb/tests/test_attributes.py
@@ -335,7 +335,7 @@ class UnicodeAttributeTestCase(TestCase):
         self.assertEqual(attr.deserialize(None), None)
         self.assertEqual(
             attr.serialize(set([six.u('foo'), six.u('bar')])),
-            set([six.u('foo'), six.u('bar')])
+            [six.u('foo'), six.u('bar')]
         )
 
     def test_round_trip_unicode_set(self):

--- a/pynamodb/tests/test_attributes.py
+++ b/pynamodb/tests/test_attributes.py
@@ -360,6 +360,18 @@ class UnicodeAttributeTestCase(TestCase):
             value
         )
 
+    def test_unicode_set_deserialize(self):
+        """
+        UnicodeSetAttribute.deserialize old way
+        """
+        attr = UnicodeSetAttribute()
+        value = set([six.u('foo'), six.u('bar')])
+        old_value = set([json.dumps(val) for val in value])
+        self.assertEqual(
+            attr.deserialize(old_value),
+            value
+        )
+
     def test_unicode_set_attribute(self):
         """
         UnicodeSetAttribute.default


### PR DESCRIPTION
When writing strings to db do not json encode them.

If they were json encoded, decode them with json. Otherwise just return them.