### PR TITLE
fix tests colliding names

### DIFF
--- a/pynamodb/tests/test_attributes.py
+++ b/pynamodb/tests/test_attributes.py
@@ -361,7 +361,7 @@ class UnicodeAttributeTestCase(TestCase):
             value
         )
 
-    def test_unicode_set_deserialize(self):
+    def test_unicode_set_deserialize_old(self):
         """
         UnicodeSetAttribute.deserialize old way
         """


### PR DESCRIPTION
There are two tests with the same name (`test_unicode_set_deserialize`), so one of them does not run.