### PR TITLE
Fixing the session headers being ignored because of prepared requests

### DIFF
--- a/pynamodb/connection/base.py
+++ b/pynamodb/connection/base.py
@@ -37,7 +37,7 @@ from pynamodb.constants import (
     ITEMS, DEFAULT_ENCODING, BINARY_SHORT, BINARY_SET_SHORT, LAST_EVALUATED_KEY, RESPONSES, UNPROCESSED_KEYS,
     UNPROCESSED_ITEMS, STREAM_SPECIFICATION, STREAM_VIEW_TYPE, STREAM_ENABLED)
 from pynamodb.settings import get_settings_value
-from requests import Request
+from botocore.vendored.requests import Request
 
 BOTOCORE_EXCEPTIONS = (BotoCoreError, ClientError)
 
@@ -239,10 +239,12 @@ class Connection(object):
         # part of the request session. In order to include the requests session headers inside
         # the request, we create a new request object, and call prepare_request with the newly
         # created request object
-        raw_request_with_params = Request(boto_prepared_request.method,
-                                boto_prepared_request.url,
-                                data=boto_prepared_request.body,
-                                headers=boto_prepared_request.headers)
+        raw_request_with_params = Request(
+            boto_prepared_request.method,
+            boto_prepared_request.url,
+            data=boto_prepared_request.body,
+            headers=boto_prepared_request.headers
+        )
 
         return self.requests_session.prepare_request(raw_request_with_params)
 

--- a/pynamodb/tests/test_base_connection.py
+++ b/pynamodb/tests/test_base_connection.py
@@ -1703,11 +1703,12 @@ class ConnectionTestCase(TestCase):
                                             'http://lyft.com',
                                             data='data',
                                             headers={'s': 's'}).prepare()
-        session_mock.create_client.return_value._endpoint.create_request.return_value = prepared_request
+        mock_client = session_mock.create_client.return_value
+        mock_client._endpoint.create_request.return_value = prepared_request
 
         c = Connection()
         c._max_retry_attempts_exception = 3
-        c._create_prepared_request({}, {})
+        c._create_prepared_request({'x': 'y'}, {'a': 'b'})
 
         self.assertEqual(len(requests_session_mock.mock_calls), 1)
 
@@ -1719,6 +1720,10 @@ class ConnectionTestCase(TestCase):
                                 prepared_request.url,
                                 data=prepared_request.body,
                                 headers=prepared_request.headers)
+
+        self.assertEqual(len(mock_client._endpoint.create_request.mock_calls), 1)
+        self.assertEqual(mock_client._endpoint.create_request.mock_calls[0],
+                         mock.call({'x': 'y'}, {'a': 'b'}))
 
         self.assertEqual(called_request_object.method, expected_request_object.method)
         self.assertEqual(called_request_object.url, expected_request_object.url)

--- a/pynamodb/tests/test_base_connection.py
+++ b/pynamodb/tests/test_base_connection.py
@@ -1695,6 +1695,37 @@ class ConnectionTestCase(TestCase):
 
         assert rand_int_mock.call_args_list == [mock.call(0, 25), mock.call(0, 50)]
 
+
+    @mock.patch('pynamodb.connection.Connection.session')
+    @mock.patch('pynamodb.connection.Connection.requests_session')
+    def test_create_prepared_request(self, requests_session_mock, session_mock):
+        prepared_request = requests.Request('POST',
+                                            'http://lyft.com',
+                                            data='data',
+                                            headers={'s': 's'}).prepare()
+        session_mock.create_client.return_value._endpoint.create_request.return_value = prepared_request
+
+        c = Connection()
+        c._max_retry_attempts_exception = 3
+        c._create_prepared_request({}, {})
+
+        self.assertEqual(len(requests_session_mock.mock_calls), 1)
+
+        self.assertEqual(requests_session_mock.mock_calls[0][:2][0],
+                         'prepare_request')
+
+        called_request_object = requests_session_mock.mock_calls[0][:2][1][0]
+        expected_request_object = requests.Request(prepared_request.method,
+                                prepared_request.url,
+                                data=prepared_request.body,
+                                headers=prepared_request.headers)
+
+        self.assertEqual(called_request_object.method, expected_request_object.method)
+        self.assertEqual(called_request_object.url, expected_request_object.url)
+        self.assertEqual(called_request_object.data, expected_request_object.data)
+        self.assertEqual(called_request_object.headers, expected_request_object.headers)
+
+
     @mock.patch('pynamodb.connection.Connection.session')
     @mock.patch('pynamodb.connection.Connection.requests_session')
     def test_make_api_call_retries_properly(self, requests_session_mock, session_mock):
@@ -1707,7 +1738,6 @@ class ConnectionTestCase(TestCase):
         bad_response.status_code = 503
 
         prepared_request = requests.Request('GET', 'http://lyft.com').prepare()
-        session_mock.create_client.return_value._endpoint.create_request.return_value = prepared_request
 
         requests_session_mock.send.side_effect = [
             bad_response,
@@ -1717,9 +1747,12 @@ class ConnectionTestCase(TestCase):
         ]
         c = Connection()
         c._max_retry_attempts_exception = 3
+        c._create_prepared_request = mock.Mock()
+        c._create_prepared_request.return_value = prepared_request
 
         c._make_api_call('DescribeTable', {'TableName': 'MyTable'})
         self.assertEqual(len(requests_session_mock.mock_calls), 4)
+
         for call in requests_session_mock.mock_calls:
             self.assertEqual(call[:2], ('send', (prepared_request,)))
 
@@ -1728,7 +1761,6 @@ class ConnectionTestCase(TestCase):
     @mock.patch('pynamodb.connection.Connection.requests_session')
     def test_make_api_call_throws_when_retries_exhausted(self, requests_session_mock, session_mock):
         prepared_request = requests.Request('GET', 'http://lyft.com').prepare()
-        session_mock.create_client.return_value._endpoint.create_request.return_value = prepared_request
 
         requests_session_mock.send.side_effect = [
             requests.ConnectionError('problems!'),
@@ -1738,6 +1770,8 @@ class ConnectionTestCase(TestCase):
         ]
         c = Connection()
         c._max_retry_attempts_exception = 3
+        c._create_prepared_request = mock.Mock()
+        c._create_prepared_request.return_value = prepared_request
 
         with self.assertRaises(requests.Timeout):
             c._make_api_call('DescribeTable', {'TableName': 'MyTable'})
@@ -1753,12 +1787,14 @@ class ConnectionTestCase(TestCase):
     @mock.patch('pynamodb.connection.Connection.requests_session')
     def test_make_api_call_throws_retry_disabled(self, requests_session_mock, session_mock, rand_int_mock):
         prepared_request = requests.Request('GET', 'http://lyft.com').prepare()
-        session_mock.create_client.return_value._endpoint.create_request.return_value = prepared_request
 
         requests_session_mock.send.side_effect = [
             requests.Timeout('problems!'),
         ]
         c = Connection(request_timeout_seconds=11, base_backoff_ms=3, max_retry_attempts=0)
+        c._create_prepared_request = mock.Mock()
+        c._create_prepared_request.return_value = prepared_request
+
         assert c._base_backoff_ms == 3
         with self.assertRaises(requests.Timeout):
             c._make_api_call('DescribeTable', {'TableName': 'MyTable'})


### PR DESCRIPTION
Ref: http://docs.python-requests.org/en/master/user/advanced/

The requests session headers are ignored in the request, if the prepared request object is passed in.
The fix calls requests_session.prepare_request by creating a request object from the aws_request_object

@danielhochman 