### PR TITLE
Add distinct DoesNotExist classes per model

### DIFF
--- a/pynamodb/models.py
+++ b/pynamodb/models.py
@@ -186,6 +186,8 @@ class MetaModel(type):
             if META_CLASS_NAME not in attrs:
                 setattr(cls, META_CLASS_NAME, DefaultMeta)
 
+            # create a custom Model.DoesNotExist derived from pynamodb.exceptions.DoesNotExist,
+            # so that "except Model.DoesNotExist:" would not catch other models' exceptions
             if 'DoesNotExist' not in attrs:
                 exception_attrs = {'__module__': attrs.get('__module__')}
                 if hasattr(cls, '__qualname__'):  # On Python 3, Model.DoesNotExist

--- a/pynamodb/models.py
+++ b/pynamodb/models.py
@@ -186,6 +186,12 @@ class MetaModel(type):
             if META_CLASS_NAME not in attrs:
                 setattr(cls, META_CLASS_NAME, DefaultMeta)
 
+            if 'DoesNotExist' not in attrs:
+                exception_attrs = {'__module__': attrs.get('__module__')}
+                if hasattr(cls, '__qualname__'):  # On Python 3, ensure its MyModel.DoesNotExist
+                    exception_attrs['__qualname__'] = '{}.{}'.format(cls.__qualname__, 'DoesNotExist')
+                cls.DoesNotExist = type('DoesNotExist', (DoesNotExist, ), exception_attrs)
+
 
 class Model(with_metaclass(MetaModel)):
     """

--- a/pynamodb/models.py
+++ b/pynamodb/models.py
@@ -188,7 +188,7 @@ class MetaModel(type):
 
             if 'DoesNotExist' not in attrs:
                 exception_attrs = {'__module__': attrs.get('__module__')}
-                if hasattr(cls, '__qualname__'):  # On Python 3, ensure its MyModel.DoesNotExist
+                if hasattr(cls, '__qualname__'):  # On Python 3, Model.DoesNotExist
                     exception_attrs['__qualname__'] = '{}.{}'.format(cls.__qualname__, 'DoesNotExist')
                 cls.DoesNotExist = type('DoesNotExist', (DoesNotExist, ), exception_attrs)
 

--- a/pynamodb/tests/test_model.py
+++ b/pynamodb/tests/test_model.py
@@ -15,7 +15,7 @@ from pynamodb.compat import CompatTestCase as TestCase
 from pynamodb.tests.deep_eq import deep_eq
 from pynamodb.throttle import Throttle
 from pynamodb.connection.util import pythonic
-from pynamodb.exceptions import TableError
+from pynamodb.exceptions import DoesNotExist, TableError
 from pynamodb.types import RANGE
 from pynamodb.constants import (
     ITEM, STRING_SHORT, ALL, KEYS_ONLY, INCLUDE, REQUEST_ITEMS, UNPROCESSED_KEYS, ITEM_COUNT,
@@ -1923,6 +1923,24 @@ class ModelTestCase(TestCase):
         with patch(PATCH_METHOD) as req:
             req.return_value = {}
             self.assertRaises(UserModel.DoesNotExist, UserModel.get, 'foo', 'bar')
+
+        with patch(PATCH_METHOD) as req:
+            req.return_value = {}
+            try:
+                UserModel.get('foo')
+            except SimpleUserModel.DoesNotExist:
+                assert False  # DoesNotExist exceptions must be distinct per-model
+            except UserModel.DoesNotExist:
+                pass
+
+        with patch(PATCH_METHOD) as req:
+            req.return_value = {}
+            try:
+                UserModel.get('foo')
+            except DoesNotExist:
+                pass
+            except UserModel.DoesNotExist:
+                assert False  # UserModel.Exception must derive from pynamodb.Exceptions.DoesNotExist
 
         with patch(PATCH_METHOD) as req:
             req.return_value = CUSTOM_ATTR_NAME_INDEX_TABLE_DATA

--- a/pynamodb/tests/test_model.py
+++ b/pynamodb/tests/test_model.py
@@ -1929,7 +1929,7 @@ class ModelTestCase(TestCase):
             try:
                 UserModel.get('foo')
             except SimpleUserModel.DoesNotExist:
-                assert False  # DoesNotExist exceptions must be distinct per-model
+                self.fail('DoesNotExist exceptions must be distinct per-model')
             except UserModel.DoesNotExist:
                 pass
 
@@ -1940,7 +1940,7 @@ class ModelTestCase(TestCase):
             except DoesNotExist:
                 pass
             except UserModel.DoesNotExist:
-                assert False  # UserModel.Exception must derive from pynamodb.Exceptions.DoesNotExist
+                self.fail('UserModel.Exception must derive from pynamodb.Exceptions.DoesNotExist')
 
         with patch(PATCH_METHOD) as req:
             req.return_value = CUSTOM_ATTR_NAME_INDEX_TABLE_DATA


### PR DESCRIPTION
It should be possible to do:
```py
try:
    doStuffWithModels()
except MyModel.DoesNotExist:
    print('My model does not exist')  # we'd end up here for MyOtherModel as well
except MyOtherModel.DoesNotExist:
    print('My other model does not exist')
```

Currently, `MyModel.DoesNotExist == MyOtherModel.DoesNotExist`. This change makes every model have its own subclass of `pynamodb.exceptions.DoesNotExist`.

btw, this is similar in spirit to what mongoengine does in https://github.com/MongoEngine/mongoengine/blob/3c455cf1c13f923db40de4a855dd402217bee3e1/mongoengine/base/metaclasses.py#L402-L407.