### PR TITLE
Update `Model::__init__` to accept dict or subclassed instance and instantiate appropriately

### DIFF
--- a/pynamodb/attributes.py
+++ b/pynamodb/attributes.py
@@ -391,20 +391,25 @@ class MapAttribute(with_metaclass(MapAttributeMeta, Attribute)):
         """
         Sets the attributes for this object
         """
-        for attr_name, attr in self._get_attributes().aliased_attrs():
-            if attr.attr_name in attrs:
-                value = attrs.get(attr_name)
-                if not isinstance(value, collections.Mapping) or type(attr) == MapAttribute:
-                    setattr(self, attr_name, attrs.get(attr.attr_name))
-                else:
-                    # it's a sub model which means we need to instantiate that type first
-                    # pass in the attributes of that model, then set the field on this object to point to that model
-                    sub_model = value
-                    instance = type(attr)(**sub_model)
-                    setattr(self, attr_name, instance)
+        class_attributes = self._get_attributes().aliased_attrs()
+        if len(class_attributes) > 0:
+            for attr_name, attr in class_attributes:
+                if attr.attr_name in attrs:
+                    value = attrs.get(attr_name)
+                    if not isinstance(value, collections.Mapping) or type(attr) == MapAttribute:
+                        setattr(self, attr_name, attrs.get(attr.attr_name))
+                    else:
+                        # it's a sub model which means we need to instantiate that type first
+                        # pass in the attributes of that model, then set the field on this object to point to that model
+                        sub_model = value
+                        instance = type(attr)(**sub_model)
+                        setattr(self, attr_name, instance)
 
-            elif attr_name in attrs:
-                setattr(self, attr_name, attrs.get(attr_name))
+                elif attr_name in attrs:
+                    setattr(self, attr_name, attrs.get(attr_name))
+        else:  # it's a raw MapAttribute
+            for in_memory_attribute_name, in_memory_attribute_value in six.iteritems(attrs):
+                setattr(self, in_memory_attribute_name, in_memory_attribute_value)
 
     def get_values(self):
         attributes = self._get_attributes()

--- a/pynamodb/attributes.py
+++ b/pynamodb/attributes.py
@@ -391,9 +391,10 @@ class MapAttribute(with_metaclass(MapAttributeMeta, Attribute)):
         """
         Sets the attributes for this object
         """
-        class_attributes = self._get_attributes().aliased_attrs()
+        class_attributes = self._get_attributes()
+        aliased_attributes = class_attributes.aliased_attrs()
         if len(class_attributes) > 0:
-            for attr_name, attr in class_attributes:
+            for attr_name, attr in aliased_attributes:
                 if attr.attr_name in attrs:
                     value = attrs.get(attr_name)
                     if not isinstance(value, collections.Mapping) or type(attr) == MapAttribute:
@@ -409,6 +410,7 @@ class MapAttribute(with_metaclass(MapAttributeMeta, Attribute)):
                     setattr(self, attr_name, attrs.get(attr_name))
         else:  # it's a raw MapAttribute
             for in_memory_attribute_name, in_memory_attribute_value in six.iteritems(attrs):
+                class_attributes[in_memory_attribute_name] = SERIALIZE_CLASS_MAP.get(type(in_memory_attribute_value))
                 setattr(self, in_memory_attribute_name, in_memory_attribute_value)
 
     def get_values(self):

--- a/pynamodb/attributes.py
+++ b/pynamodb/attributes.py
@@ -387,6 +387,14 @@ class MapAttribute(with_metaclass(MapAttributeMeta, Attribute)):
                 cls._attributes[item] = instance
         return cls._attributes
 
+    def _get_in_memory_attributes(self):
+        try:
+            in_memory_attributes = getattr(self, 'in_memory_attributes')
+        except AttributeError:
+            self.in_memory_attributes = AttributeDict()
+            in_memory_attributes = self.in_memory_attributes
+        return in_memory_attributes
+
     def _set_attributes(self, **attrs):
         """
         Sets the attributes for this object
@@ -409,12 +417,14 @@ class MapAttribute(with_metaclass(MapAttributeMeta, Attribute)):
                 elif attr_name in attrs:
                     setattr(self, attr_name, attrs.get(attr_name))
         else:  # it's a raw MapAttribute
+            in_memory_attributes = self._get_in_memory_attributes()
             for in_memory_attribute_name, in_memory_attribute_value in six.iteritems(attrs):
-                class_attributes[in_memory_attribute_name] = SERIALIZE_CLASS_MAP.get(type(in_memory_attribute_value))
+                in_memory_attributes[in_memory_attribute_name] = SERIALIZE_CLASS_MAP.get(type(in_memory_attribute_value))
                 setattr(self, in_memory_attribute_name, in_memory_attribute_value)
 
     def get_values(self):
         attributes = self._get_attributes()
+        attributes.update(self._get_in_memory_attributes())
         result = {}
         for k, v in six.iteritems(attributes):
             result[k] = getattr(self, k)

--- a/pynamodb/attributes.py
+++ b/pynamodb/attributes.py
@@ -388,12 +388,10 @@ class MapAttribute(with_metaclass(MapAttributeMeta, Attribute)):
         return cls._attributes
 
     def _get_in_memory_attributes(self):
-        try:
-            in_memory_attributes = getattr(self, 'in_memory_attributes')
-        except AttributeError:
-            self.in_memory_attributes = AttributeDict()
-            in_memory_attributes = self.in_memory_attributes
-        return in_memory_attributes
+        if hasattr(self, 'in_memory_attributes'):
+            return self.in_memory_attributes
+        self.in_memory_attributes = AttributeDict()
+        return self.in_memory_attributes
 
     def _set_attributes(self, **attrs):
         """
@@ -401,7 +399,7 @@ class MapAttribute(with_metaclass(MapAttributeMeta, Attribute)):
         """
         class_attributes = self._get_attributes()
         aliased_attributes = class_attributes.aliased_attrs()
-        if len(class_attributes) > 0:
+        if class_attributes:
             for attr_name, attr in aliased_attributes:
                 if attr.attr_name in attrs:
                     value = attrs.get(attr_name)

--- a/pynamodb/models.py
+++ b/pynamodb/models.py
@@ -1241,7 +1241,8 @@ class Model(with_metaclass(MetaModel)):
                 attribute_to_set = getattr(self, attr_name)
                 if isinstance(attribute_to_set, Mapping):
                     cls = getattr(self, attribute_name)
-                    attribute_to_set = cls(**attribute_to_set)
+                    if cls is not MapAttribute:
+                        attribute_to_set = cls(**attribute_to_set)
                 setattr(self, attr_name, attribute_to_set)
 
     @classmethod

--- a/pynamodb/models.py
+++ b/pynamodb/models.py
@@ -1240,9 +1240,9 @@ class Model(with_metaclass(MetaModel)):
             if attribute_name is not None:
                 attribute_to_set = attrs.get(attribute_name)
                 if isinstance(attribute_to_set, Mapping):
-                    cls = getattr(self, attribute_name)
-                    if cls is not MapAttribute:
-                        attribute_to_set = cls(**attribute_to_set)
+                    kls = getattr(self.__class__, attribute_name).__class__
+                    if kls is not MapAttribute and kls is not None.__class__ and attribute_to_set is not None:
+                        attribute_to_set = kls(**attribute_to_set)
                 setattr(self, attr_name, attribute_to_set)
 
     @classmethod

--- a/pynamodb/models.py
+++ b/pynamodb/models.py
@@ -8,6 +8,7 @@ import copy
 import logging
 import warnings
 
+from collections import Mapping
 from six import with_metaclass
 from pynamodb.exceptions import DoesNotExist, TableDoesNotExist, TableError
 from pynamodb.throttle import NoThrottle
@@ -1231,10 +1232,17 @@ class Model(with_metaclass(MetaModel)):
         Sets the attributes for this object
         """
         for attr_name, attr in self._get_attributes().aliased_attrs():
+            attribute_name = None
             if attr.attr_name in attrs:
-                setattr(self, attr_name, attrs.get(attr.attr_name))
+                attribute_name = attr.attr_name
             elif attr_name in attrs:
-                setattr(self, attr_name, attrs.get(attr_name))
+                attribute_name = attr_name
+            if attribute_name is not None:
+                attribute_to_set = getattr(self, attr_name)
+                if isinstance(attribute_to_set, Mapping):
+                    cls = getattr(self, attribute_name)
+                    attribute_to_set = cls(**attribute_to_set)
+                setattr(self, attr_name, attribute_to_set)
 
     @classmethod
     def add_throttle_record(cls, records):

--- a/pynamodb/models.py
+++ b/pynamodb/models.py
@@ -1238,7 +1238,7 @@ class Model(with_metaclass(MetaModel)):
             elif attr_name in attrs:
                 attribute_name = attr_name
             if attribute_name is not None:
-                attribute_to_set = getattr(self, attr_name)
+                attribute_to_set = attrs.get(attribute_name)
                 if isinstance(attribute_to_set, Mapping):
                     cls = getattr(self, attribute_name)
                     if cls is not MapAttribute:

--- a/pynamodb/models.py
+++ b/pynamodb/models.py
@@ -1239,12 +1239,9 @@ class Model(with_metaclass(MetaModel)):
                 attribute_name = attr_name
             if attribute_name is not None:
                 attribute_to_set = attrs.get(attribute_name)
-                if isinstance(attribute_to_set, MapAttribute):
-                    if attribute_to_set.__class__ is MapAttribute:
-                        raise AttributeError('Cannot initialize with non subclassed MapAttribute')
                 if isinstance(attribute_to_set, Mapping):
                     kls = getattr(self.__class__, attribute_name).__class__
-                    if kls is not MapAttribute and kls is not None.__class__ and attribute_to_set is not None:
+                    if kls is not None.__class__ and attribute_to_set is not None:
                         attribute_to_set = kls(**attribute_to_set)
                 setattr(self, attr_name, attribute_to_set)
 

--- a/pynamodb/models.py
+++ b/pynamodb/models.py
@@ -1239,6 +1239,9 @@ class Model(with_metaclass(MetaModel)):
                 attribute_name = attr_name
             if attribute_name is not None:
                 attribute_to_set = attrs.get(attribute_name)
+                if isinstance(attribute_to_set, MapAttribute):
+                    if attribute_to_set.__class__ is MapAttribute:
+                        raise AttributeError('Cannot initialize with non subclassed MapAttribute')
                 if isinstance(attribute_to_set, Mapping):
                     kls = getattr(self.__class__, attribute_name).__class__
                     if kls is not MapAttribute and kls is not None.__class__ and attribute_to_set is not None:

--- a/pynamodb/tests/test_model.py
+++ b/pynamodb/tests/test_model.py
@@ -3400,3 +3400,88 @@ class ModelTestCase(TestCase):
                              map_native.get('mapy', {}).get('baz'))
 
 
+class ModelInitTestCase(TestCase):
+
+    def test_raw_map_attribute_with_dict_init(self):
+        attribute = {
+            'foo': 123,
+            'bar': 'baz'
+        }
+        actual = ExplicitRawMapModel(map_id=3, map_attr=attribute)
+        self.assertEquals(actual.map_attr, attribute)
+        self.assertEquals(actual.map_attr.get('foo'), attribute.get('foo'))
+        self.assertIsNotNone(actual.map_attr.get('foo'))
+
+    def test_raw_map_attribute_with_initialized_instance_init(self):
+        attribute = {
+            'foo': 123,
+            'bar': 'baz'
+        }
+        initialized_instance = MapAttribute(**attribute)
+        actual = ExplicitRawMapModel(map_id=3, map_attr=initialized_instance)
+        self.assertEquals(actual.map_attr.get('foo'), attribute.get('foo'))
+        self.assertIsNotNone(actual.map_attr.get('foo'))
+        self.assertEquals(attribute, actual.map_attr)
+
+    def test_subclassed_map_attribute_with_dict_init(self):
+        attribute = {
+            'make': 'Volkswagen',
+            'model': 'Super Beetle'
+        }
+        expected_model = CarInfoMap(**attribute)
+        actual = CarModel(car_id=1, car_info=attribute)
+        self.assertEquals(expected_model.make, actual.car_info.make)
+        self.assertEquals(expected_model.model, actual.car_info.model)
+
+    def test_subclassed_map_attribute_with_initialized_instance_init(self):
+        attribute = {
+            'make': 'Volkswagen',
+            'model': 'Super Beetle'
+        }
+        expected_model = CarInfoMap(**attribute)
+        actual = CarModel(car_id=1, car_info=expected_model)
+        self.assertEquals(expected_model.make, actual.car_info.make)
+        self.assertEquals(expected_model.model, actual.car_info.model)
+
+    def _get_bin_tree(self, multiplier=1):
+        return {
+            'value': 5 * multiplier,
+            'left': {
+                'value': 2 * multiplier,
+                'left': {
+                    'value': 1 * multiplier
+                },
+                'right': {
+                    'value': 3 * multiplier
+                }
+            },
+            'right': {
+                'value': 7 * multiplier,
+                'left': {
+                    'value': 6 * multiplier
+                },
+                'right': {
+                    'value': 8 * multiplier
+                }
+            }
+        }
+
+    def test_subclassed_map_attribute_with_map_attributes_member_with_dict_init(self):
+        left = self._get_bin_tree()
+        right = self._get_bin_tree(multiplier=2)
+        actual = TreeModel(tree_key='key', left=left, right=right)
+        self.assertEquals(actual.left.left.right.value, 3)
+        self.assertEquals(actual.left.left.value, 2)
+        self.assertEquals(actual.right.right.left.value, 12)
+        self.assertEquals(actual.right.right.value, 14)
+
+    def test_subclassed_map_attribute_with_map_apttribute_member_with_initialized_instance_init(self):
+        left = self._get_bin_tree()
+        right = self._get_bin_tree(multiplier=2)
+        left_instance = TreeLeaf(**left)
+        right_instance = TreeLeaf(**right)
+        actual = TreeModel(tree_key='key', left=left_instance, right=right_instance)
+        self.assertEquals(actual.left.left.right.value, left_instance.left.right.value)
+        self.assertEquals(actual.left.left.value, left_instance.left.value)
+        self.assertEquals(actual.right.right.left.value, right_instance.right.left.value)
+        self.assertEquals(actual.right.right.value, right_instance.right.value)

--- a/pynamodb/tests/test_model.py
+++ b/pynamodb/tests/test_model.py
@@ -3408,9 +3408,7 @@ class ModelInitTestCase(TestCase):
             'bar': 'baz'
         }
         actual = ExplicitRawMapModel(map_id=3, map_attr=attribute)
-        self.assertEquals(actual.map_attr, attribute)
-        self.assertEquals(actual.map_attr.get('foo'), attribute.get('foo'))
-        self.assertIsNotNone(actual.map_attr.get('foo'))
+        self.assertEquals(actual.map_attr['foo'], attribute['foo'])
 
     def test_raw_map_attribute_with_initialized_instance_init(self):
         attribute = {
@@ -3418,10 +3416,8 @@ class ModelInitTestCase(TestCase):
             'bar': 'baz'
         }
         initialized_instance = MapAttribute(**attribute)
-        actual = ExplicitRawMapModel(map_id=3, map_attr=initialized_instance)
-        self.assertEquals(actual.map_attr.get('foo'), attribute.get('foo'))
-        self.assertIsNotNone(actual.map_attr.get('foo'))
-        self.assertEquals(attribute, actual.map_attr)
+        with self.assertRaises(AttributeError):
+            ExplicitRawMapModel(map_id=3, map_attr=initialized_instance)
 
     def test_subclassed_map_attribute_with_dict_init(self):
         attribute = {

--- a/pynamodb/tests/test_model.py
+++ b/pynamodb/tests/test_model.py
@@ -3297,7 +3297,7 @@ class ModelTestCase(TestCase):
         instance._deserialize(map_serialized)
         actual = instance.map_attr
         for k,v in six.iteritems(map_native):
-            self.assertEqual(v, actual[k])
+            self.assertEqual(v, getattr(actual, k))
 
     def test_raw_map_from_raw_data_works(self):
         map_native = {
@@ -3325,9 +3325,9 @@ class ModelTestCase(TestCase):
         with patch(PATCH_METHOD, new=fake_db) as req:
             item = ExplicitRawMapModel.get(123)
             actual = item.map_attr
-            self.assertEqual(map_native.get('listy')[2], actual.get('listy')[2])
+            self.assertEqual(map_native.get('listy')[2], actual.listy[2])
             for k, v in six.iteritems(map_native):
-                self.assertEqual(v, actual[k])
+                self.assertEqual(v, getattr(actual, k))
 
     def test_raw_map_as_sub_map_serialize_pass(self):
         map_native = {'a': 'dict', 'lives': [123, 456], 'here': True}

--- a/pynamodb/tests/test_model.py
+++ b/pynamodb/tests/test_model.py
@@ -3408,7 +3408,9 @@ class ModelInitTestCase(TestCase):
             'bar': 'baz'
         }
         actual = ExplicitRawMapModel(map_id=3, map_attr=attribute)
-        self.assertEquals(actual.map_attr['foo'], attribute['foo'])
+        print(attribute['foo'])
+        print(actual.map_attr.foo)
+        self.assertEquals(actual.map_attr.foo, attribute['foo'])
 
     def test_raw_map_attribute_with_initialized_instance_init(self):
         attribute = {
@@ -3416,8 +3418,9 @@ class ModelInitTestCase(TestCase):
             'bar': 'baz'
         }
         initialized_instance = MapAttribute(**attribute)
-        with self.assertRaises(AttributeError):
-            ExplicitRawMapModel(map_id=3, map_attr=initialized_instance)
+        actual = ExplicitRawMapModel(map_id=3, map_attr=initialized_instance)
+        self.assertEquals(actual.map_attr.foo, initialized_instance.foo)
+        self.assertEquals(actual.map_attr.foo, attribute['foo'])
 
     def test_subclassed_map_attribute_with_dict_init(self):
         attribute = {


### PR DESCRIPTION
The `Model::__init__` method should instantiate any subclassed `MapAttribute` if passed a dictionary, or set the passed instantiated instance on the current model.