### PR TITLE
Ensure defaults are respected for MapAttribute

### DIFF
--- a/pynamodb/models.py
+++ b/pynamodb/models.py
@@ -1199,19 +1199,6 @@ class Model(AttributeContainer):
         unprocessed_items = data.get(UNPROCESSED_KEYS).get(cls.Meta.table_name, {}).get(KEYS, None)
         return item_data, unprocessed_items
 
-    def _set_defaults(self):
-        """
-        Sets and fields that provide a default value
-        """
-        for name, attr in self._get_attributes().items():
-            default = attr.default
-            if callable(default):
-                value = default()
-            else:
-                value = default
-            if value is not None:
-                setattr(self, name, value)
-
     def _set_attributes(self, **attrs):
         """
         Sets the attributes for this object

--- a/pynamodb/tests/test_attributes.py
+++ b/pynamodb/tests/test_attributes.py
@@ -40,6 +40,10 @@ class CustomAttrMap(MapAttribute):
     overridden_unicode_attr = UnicodeAttribute(attr_name="unicode_attr")
 
 
+class DefaultsMap(MapAttribute):
+    map_field = MapAttribute(default={})
+
+
 class AttributeDescriptorTestCase(TestCase):
     """
     Test Attribute Descriptors
@@ -562,6 +566,15 @@ class MapAttributeTestCase(TestCase):
             {'number_attr': {'N': '10'}, 'unicode_attr': {'S': six.u('Hello')}},
             CustomAttrMap().serialize(attribute)
         )
+
+    def test_defaults(self):
+        item = DefaultsMap()
+        self.assertTrue(item.validate())
+        self.assertEquals(DefaultsMap().serialize(item), {
+            'map_field': {
+                'M': {}
+            }
+        })
 
 
 class MapAndListAttributeTestCase(TestCase):

--- a/pynamodb/tests/test_model.py
+++ b/pynamodb/tests/test_model.py
@@ -3338,18 +3338,6 @@ class ModelTestCase(TestCase):
             'other_b_type': False, 'floaty': 1.2, 'listy': [1, 2, 12345678909876543211234234324234],
             'mapy': {'baz': 'bongo'}
         }
-        map_serialized = {
-            'M': {
-                'foo': {'S': 'bar'},
-                'num': {'N': 1},
-                'bool_type': {'BOOL': True},
-                'other_b_type': {'BOOL': False},
-                'floaty': {'N': 1.2},
-                'listy': {'L': [{'N': 1}, {'N': 2}, {'N': 1234567890987654321}]},
-                'mapy': {'M': {'baz': {'S': 'bongo'}}}
-            }
-        }
-        instance = ExplicitRawMapModel(map_attr=map_native, map_id=123)
         fake_db = self.database_mocker(ExplicitRawMapModel,
                                        EXPLICIT_RAW_MAP_MODEL_TABLE_DATA,
                                        EXPLICIT_RAW_MAP_MODEL_ITEM_DATA,
@@ -3426,10 +3414,7 @@ class ModelTestCase(TestCase):
                                        '123')
         with patch(PATCH_METHOD, new=fake_db) as req:
             item = ExplicitRawMapAsMemberOfSubClass.get(123)
-            actual = item.sub_attr
             self.assertEqual(sub_attr.map_field.get('floaty'),
                              map_native.get('floaty'))
             self.assertEqual(sub_attr.map_field.get('mapy', {}).get('baz'),
                              map_native.get('mapy', {}).get('baz'))
-
-


### PR DESCRIPTION
Defaults were never being set on `MapAttribute`s.

Also removes some complicated type validation logic that was never _actually_ validating types. Leaving that to a future PR, as it's a much larger task.