### PR TITLE
Always create map attributes when setting a dict

### DIFF
--- a/pynamodb/models.py
+++ b/pynamodb/models.py
@@ -500,10 +500,7 @@ class Model(AttributeContainer):
             attr_name = cls._dynamo_to_python_attr(name)
             attr = cls._get_attributes().get(attr_name, None)
             if attr:
-                deserialized_attr = attr.deserialize(attr.get_value(value))
-                if isinstance(attr, MapAttribute) and not type(attr) == MapAttribute:
-                    deserialized_attr = type(attr)(**deserialized_attr)
-                kwargs[attr_name] = deserialized_attr
+                kwargs[attr_name] = attr.deserialize(attr.get_value(value))
         return cls(*args, **kwargs)
 
     @classmethod
@@ -1295,7 +1292,6 @@ class Model(AttributeContainer):
             if isinstance(value, MapAttribute):
                 if not value.validate():
                     raise ValueError("Attribute '{0}' is not correctly typed".format(attr.attr_name))
-                value = value.get_values()
 
             serialized = self._serialize_value(attr, value, null_check)
             if NULL in serialized:

--- a/pynamodb/tests/test_attributes.py
+++ b/pynamodb/tests/test_attributes.py
@@ -33,6 +33,7 @@ class AttributeTestModel(Model):
     datetime_attr = UTCDateTimeAttribute()
     bool_attr = BooleanAttribute()
     json_attr = JSONAttribute()
+    map_attr = MapAttribute()
 
 
 class CustomAttrMap(MapAttribute):
@@ -575,6 +576,62 @@ class MapAttributeTestCase(TestCase):
                 'M': {}
             }
         })
+
+    def test_raw_map_from_dict(self):
+        item = AttributeTestModel(
+            map_attr={
+                "foo": "bar",
+                "num": 3,
+                "nested": {
+                    "nestedfoo": "nestedbar"
+                }
+            }
+        )
+
+        self.assertEqual(item.map_attr['foo'], 'bar')
+        self.assertEqual(item.map_attr['num'], 3)
+
+    def test_raw_map_access(self):
+        raw = {
+            "foo": "bar",
+            "num": 3,
+            "nested": {
+                "nestedfoo": "nestedbar"
+            }
+        }
+        attr = MapAttribute(**raw)
+
+        for k, v in six.iteritems(raw):
+            self.assertEquals(attr[k], v)
+
+    def test_raw_map_json_serialize(self):
+        raw = {
+            "foo": "bar",
+            "num": 3,
+            "nested": {
+                "nestedfoo": "nestedbar"
+            }
+        }
+
+        serialized_raw = json.dumps(raw)
+        self.assertEqual(json.dumps(AttributeTestModel(map_attr=raw).map_attr.as_dict()),
+                         serialized_raw)
+        self.assertEqual(json.dumps(AttributeTestModel(map_attr=MapAttribute(**raw)).map_attr.as_dict()),
+                         serialized_raw)
+
+    def test_typed_and_raw_map_json_serialize(self):
+        class TypedMap(MapAttribute):
+            map_attr = MapAttribute()
+
+        class SomeModel(Model):
+            typed_map = TypedMap()
+
+        item = SomeModel(
+            typed_map=TypedMap(map_attr={'foo': 'bar'})
+        )
+
+        self.assertEqual(json.dumps({'map_attr': {'foo': 'bar'}}),
+                         json.dumps(item.typed_map.as_dict()))
 
 
 class MapAndListAttributeTestCase(TestCase):


### PR DESCRIPTION
Alternate implementation of https://github.com/jlafon/PynamoDB/pull/213

Note that this changes the semantics of `MapAttribute`s a little such that you will _always_ get back a `MapAttribute` instance when accessing via a parent (Model or MapAttribute) and be required to call `.as_dict()` to convert into a raw dict.

The aim of doing this is consistency -- whether you instantiate a model like `Model(attr={...})` or `Model(attr=MapAttribute())` you should get the same result back when accessing via `model.attr`.

This is a breaking change so we should be sure to document it well in release notes.