### PR TITLE
Small update to API docs: include example for updating ProvisionedThroughput on a GSI

### DIFF
--- a/docs/low_level.rst
+++ b/docs/low_level.rst
@@ -80,8 +80,22 @@ but here is a low level example to demonstrate the point:
             }
         ]
     }
-    conn.create_table('tablename', **kwargs)
+    conn.create_table('table_name', **kwargs)
 
+You can also use `update_table` to change the Provisioned Throughput capacity of Global Secondary Indexes:
+
+.. code-block:: python
+
+    >>> kwargs = {
+        'global_secondary_index_updates': [
+            {
+                'index_name': 'index_name',
+                'read_capacity_units': 10,
+                'write_capacity_units': 10
+            }
+        ]
+    }
+    >>> conn.update_table('table_name', **kwargs)
 
 Modifying items
 ^^^^^^^^^^^^^^^


### PR DESCRIPTION
- Include example for using `update_table` to update ProvisionedThroughput on a Global Secondary Index.
- Use consistent tablename/table_name dummy var.