### PR TITLE
use range key when not none, otherwise batch get all without range

### DIFF
--- a/pynamodb/models.py
+++ b/pynamodb/models.py
@@ -270,7 +270,7 @@ class Model(AttributeContainer):
                     else:
                         keys_to_get = []
             item = items.pop()
-            if range_keyname:
+            if range_keyname and item[1] is not None:
                 hash_key, range_key = cls._serialize_keys(item[0], item[1])
                 keys_to_get.append({
                     hash_keyname: hash_key,


### PR DESCRIPTION
allows us to look up all models by hash key when range is defined
```python
identifiers = [(identifier, None) for identifier in identifiers]
for result in model.batch_get(identifiers):
```