### PR TITLE
Fix "test_raw_map_json_serialize" when dict ordering differs

### DIFF
--- a/pynamodb/tests/test_attributes.py
+++ b/pynamodb/tests/test_attributes.py
@@ -613,11 +613,11 @@ class MapAttributeTestCase(TestCase):
             }
         }
 
-        serialized_raw = json.dumps(raw)
-        self.assertEqual(json.dumps(AttributeTestModel(map_attr=raw).map_attr.as_dict()),
-                         serialized_raw)
-        self.assertEqual(json.dumps(AttributeTestModel(map_attr=MapAttribute(**raw)).map_attr.as_dict()),
-                         serialized_raw)
+        serialized_raw = json.dumps(raw, sort_keys=True)
+        self.assertEqual(json.dumps(AttributeTestModel(map_attr=raw).map_attr.as_dict(),
+                         sort_keys=True), serialized_raw)
+        self.assertEqual(json.dumps(AttributeTestModel(map_attr=MapAttribute(**raw)).map_attr.as_dict(),
+                         sort_keys=True), serialized_raw)
 
     def test_typed_and_raw_map_json_serialize(self):
         class TypedMap(MapAttribute):


### PR DESCRIPTION
Without keys sorted, an `AssertionError` was being raised on:

```
AssertionError: '{"foo": "bar", "nested": {"nestedfoo": "nestedbar"}, "num": 3}' != '{"num": 3, "foo": "bar", "nested": {"nestedfoo": "nestedbar"}}'
- {"foo": "bar", "nested": {"nestedfoo": "nestedbar"}, "num": 3}
?                                                    ----------
+ {"num": 3, "foo": "bar", "nested": {"nestedfoo": "nestedbar"}}
?  ++++++++++
```